### PR TITLE
Sort revisions list by modification date

### DIFF
--- a/lib/s3-adapter.js
+++ b/lib/s3-adapter.js
@@ -59,10 +59,18 @@ module.exports = Adapter.extend({
 
   _list: function() {
     return this._getBucketContents()
+    .then(this._sortBucketContent.bind(this))
     .then(this._removeCurrentRevisionFromContents.bind(this))
     .then(this._getBucketRevisions.bind(this))
   },
 
+  _sortBucketContent: function(data) {
+    data.Contents = data.Contents.sort(function(a, b) {
+      return b.LastModified - a.LastModified;
+    });
+
+    return data;
+  },
 
   /**
    * Gets all current revisions based on the bucket's content


### PR DESCRIPTION
Thx for this great adapter! 

I was a little bit surprised that the revisions list is not ordered chronological. While trying out this addon I activated the wrong revisions multiple times because I am used to a chronological ordering from `ember-deploy-redis` ;)

Actually this just needed a little change and the revision list now prints out the latest revisions on top.

I hope this is a useful addition to this great project! 
