### PR TITLE
Removed forceful AWS Credentials Check

### DIFF
--- a/lib/s3-adapter.js
+++ b/lib/s3-adapter.js
@@ -17,10 +17,6 @@ module.exports = Adapter.extend({
       return Promise.reject(new SilentError('You must supply a config'));
     }
 
-    if (!this.config.accessKeyId || !this.config.secretAccessKey) {
-      return Promise.reject(new SilentError('You must supply your AWS Access Key Id and Secret Access Key'));      
-    }
-    
     this.client = new AWS.S3(this.config);    
     this.manifestSize = this.manifestSize || DEFAULT_MANIFEST_SIZE;
     this.taggingAdapter = this.taggingAdapter || this._createTaggingAdapter(); 


### PR DESCRIPTION
The AWS node SDK has [many ways to authenticate](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html).

I use a `~/.aws/credentials` file locally and EC2 instances with IAM roles. This check prevents those methods from working.
