### PR TITLE
remove dependency on ember-deploy for compatibility with ember-cli-deploy 

### DIFF
--- a/lib/s3-adapter.js
+++ b/lib/s3-adapter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Adapter = require('ember-deploy/utilities/adapter');
+var CoreObject  = require('core-object');
 var Promise = require('ember-cli/lib/ext/promise');
 var SilentError = require('ember-cli/lib/errors/silent');
 var AWS = require('aws-sdk');
@@ -11,15 +11,15 @@ var white = chalk.white;
 
 var DEFAULT_MANIFEST_SIZE = 5;
 
-module.exports = Adapter.extend({
+module.exports = CoreObject.extend({
   init: function() {
+    CoreObject.prototype.init.apply(this, arguments);
     if (!this.config) {
       return Promise.reject(new SilentError('You must supply a config'));
     }
 
     this.client = new AWS.S3(this.config);
     this.manifestSize = this.manifestSize || DEFAULT_MANIFEST_SIZE;
-    this.taggingAdapter = this.taggingAdapter || this._createTaggingAdapter();
   },
 
   /* Public methods */
@@ -168,13 +168,6 @@ module.exports = Adapter.extend({
         }
       }.bind(this));
     }.bind(this));
-  },
-
-  _createTaggingAdapter: function() {
-    var TaggingAdapter = require('ember-deploy/utilities/tagging/sha');
-    return new TaggingAdapter({
-      manifest: this.manifest
-    });
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "aws-sdk": "^2.1.10",
     "chalk": "^0.5.1",
-    "ember-deploy": "^0.3.1"
+    "core-object": "^1.1.0"
   }
 }


### PR DESCRIPTION
As ember-cli-deploy moves towards a release, in order to allow this plugin to work with both ember-deploy and ember-cli-deploy at the same time, I've removed the dependency on ember-deploy. That allows this plugin to currently work with ember-cli-deploy and should keep it working unless a breaking API change is introduced (which is not slated for the initial release).

@LevelbossMike - can you put a eyeball on this also please.
