### PR TITLE
include test runner. simple s3dapter test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+---
+language: node_js
+
+node_js:
+  - '0.10.26'
+  - '0.10.36'
+  - '0.12.0'
+
+sudo: false
+
+cache:
+  directories:
+    - node_modules
+
+install:
+  - npm install
+  - npm install -d
+
+script:
+  - npm test

--- a/lib/s3-adapter.js
+++ b/lib/s3-adapter.js
@@ -14,8 +14,9 @@ var DEFAULT_MANIFEST_SIZE = 5;
 module.exports = CoreObject.extend({
   init: function() {
     CoreObject.prototype.init.apply(this, arguments);
+
     if (!this.config) {
-      return Promise.reject(new SilentError('You must supply a config'));
+      throw new SilentError('You must supply a config');
     }
 
     this.client = new AWS.S3(this.config);

--- a/node_tests/runner.js
+++ b/node_tests/runner.js
@@ -1,0 +1,21 @@
+var glob  = require('glob');
+var Mocha = require('mocha');
+
+var mocha = new Mocha({
+  timeout: 6000,
+  reporter: 'spec'
+});
+
+var directory = 'node_tests';
+
+var files = glob(directory + '/**/*-test.js', { sync: true });
+
+files.forEach(function(file) {
+  mocha.addFile(file);
+});
+
+mocha.run(function(failures) {
+  process.on('exit', function() {
+    process.exit(failures);
+  });
+});

--- a/node_tests/unit/s3-adapter-test.js
+++ b/node_tests/unit/s3-adapter-test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var assert    = require('assert');
+var S3Adapter = require('../../lib/s3-adapter');
+
+describe('S3Adapter tests', function() {
+  var adapter;
+
+  it('requires config to instantiate S3 Adapter', function() {
+
+    assert.throws(function() {
+      new S3Adapter();
+    }, function(error) {
+      return ('You must supply a config' === error.message);
+    }, "Should error when not supplying a config on instantiation");
+
+    assert.doesNotThrow(function() {
+      new S3Adapter({
+        config: {}
+      });
+    }, "Should not error when supplied a config on instantiation");
+
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -3,19 +3,21 @@
   "version": "0.1.1",
   "description": "ember-deploy index-adapter for Amazon S3",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node node_tests/runner.js"
   },
   "keywords": [
     "ember-addon"
   ],
   "author": "Kerry Gallagher",
   "license": "MIT",
-  "repository" :
-    { "type" : "git",
-      "url" : "https://github.com/Kerry350/ember-deploy-s3-index.git"
-    },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kerry350/ember-deploy-s3-index.git"
+  },
   "devDependencies": {
-    "ember-cli": "^0.1.15"
+    "ember-cli": "^0.1.15",
+    "glob": "^4.4.2",
+    "mocha": "^2.1.0"
   },
   "dependencies": {
     "aws-sdk": "^2.1.10",


### PR DESCRIPTION
basic test runner, travis file, and an initial test.

most notable change is throwing error when calling `new S3Adapter()` instead of returning a rejected promise - Wasn't able to capture the Promise rejection when calling `new` and this seemed like more suitable behavior?

_ps_ test runner may seem like overkill for testing a single file. However it may be helpful if s3-adapter.js gets broken into smaller pieces or when adding files for integration tests against the main ember-deploy addon.
