### PR TITLE
updating to push website configuration data on activate

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The add-on uses one set of logic, but allows you the freedom to use those files 
       "type": "S3",
       "accessKeyId": "<key>",
       "secretAccessKey": "<key>",
-      "bucket": "my-index-bucket"
+      "bucket": "my-index-bucket",
+      "hostName": "my-index-bucket.s3-my-region.amazonaws.com"
     },
 
     "assets": {

--- a/lib/s3-adapter.js
+++ b/lib/s3-adapter.js
@@ -119,8 +119,7 @@ module.exports = CoreObject.extend({
     if (currentRevisions.indexOf(revision) > -1) {
       return new Promise(function(resolve, reject) {
         this._getFileContents(revision + '.html')
-        .then(this._getUploadParams.bind(this, 'index'))
-        .then(this._setFileContents.bind(this))
+        .then(this._updateBucketWebsite.bind(this, revision))
         .then(function() {
           resolve();
         })
@@ -291,6 +290,55 @@ module.exports = CoreObject.extend({
         }
       }.bind(this));
     }.bind(this));
+  },
+
+ /**
+  * Updates website index document to point to a new revision.
+  * @param {string} revision - revision to update index to
+  * @returns {RSVP.Promise}
+  */
+  _updateBucketWebsite: function(revision){
+    return new Promise(function(resolve, reject) {
+      var params = this._getWebsiteParams(revision);
+      this.client.putBucketWebsite(params, function(err, data) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data.Body);
+        }
+      });
+    }.bind(this));
+  },
+
+ /**
+  * Generates parameters for bucket website configuration.
+  * @param {string} revision - revision to update index to
+  * @returns {Object}
+  */
+  _getWebsiteParams: function(revision){
+    return {
+      Bucket: this.config. bucket, /* required */
+      WebsiteConfiguration: { /* required */
+        ErrorDocument: {
+          Key: 'error.html' /* required */
+        },
+        IndexDocument: {
+          Suffix: revision +'.html' /* required */
+        },
+
+        RoutingRules: [
+          {
+          Redirect: { /* required */
+            HostName: this.config.hostName,
+            ReplaceKeyPrefixWith: '#/',
+          },
+          Condition: {
+            HttpErrorCodeReturnedEquals: '404',
+          }
+        },
+        ]
+      }
+    };
   },
 
   _getUploadParams: function(key, value) {

--- a/lib/s3-adapter.js
+++ b/lib/s3-adapter.js
@@ -317,7 +317,7 @@ module.exports = CoreObject.extend({
   */
   _getWebsiteParams: function(revision){
     return {
-      Bucket: this.config. bucket, /* required */
+      Bucket: this.config.bucket, /* required */
       WebsiteConfiguration: { /* required */
         ErrorDocument: {
           Key: 'error.html' /* required */


### PR DESCRIPTION
Using this in my own application, because it allows us to keep a static reference to the bucket url and not have to update it after the activate. bucket-name-s3-website-us-east-1.amazonaws.com, instead of appending the /index.html. 

It allows us to build a really easy activation dashboard where we can quickly see what the current revision is on each bucket.

I know @quiddle is working on some similar pieces, and the ember-cli-deploy api is still in flux, so you may want to hold off on these kinds of updates, but PRing just in case it’s useful.
