### PR TITLE
Throws activation error when no response body is present

### DIFF
--- a/lib/s3-adapter.js
+++ b/lib/s3-adapter.js
@@ -321,6 +321,8 @@ module.exports = CoreObject.extend({
       this.client.putBucketWebsite(params, function(err, data) {
         if (err) {
           reject(err);
+        } else if (!data.Body) {
+          reject(new SilentError('No data received: please verify correct "indexMode" config.'));
         } else {
           resolve(data.Body);
         }
@@ -407,7 +409,7 @@ module.exports = CoreObject.extend({
 
   _getFormattedErrorMessage: function(message, error) {
     message = message + '\n\n';
-    error = (error) ? (error.stack + '\n') : '';
+    error = (error) ? (error.stack || error.message + '\n') : '';
     return message + error;
   }
 });


### PR DESCRIPTION
Helps to avoid the problem when a user didn't set `indexMode` while trying to activate a revision on a non-website bucket and doesn't get any (positive or negative) feedback.
