### PR TITLE
update README to show region config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ module.exports = {
       accessKeyId: "ID",
       secretAccessKey: "KEY",
       bucket: "BUCKET",
+      region: "ap-southeast-2", // if your bucket isn't in us-east-1
       acl: 'public-read', //optional, e.g. 'public-read', if ACL is not configured, it is not sent
       hostName: "my-index-bucket.s3-my-region.amazonaws.com", // To be set with 'direct' indexMode
       indexMode: "indirect", // Optional: 'direct' or 'indirect', 'direct' is used by default.
@@ -40,7 +41,8 @@ module.exports = {
       type: "s3",
       accessKeyId: "ID",
       secretAccessKey: "KEY",
-      bucket: "BUCKET"
+      bucket: "BUCKET",
+      region: "ap-southeast-2" // if your bucket isn't in us-east-1
     }
   }
 }


### PR DESCRIPTION
S3 buckets outside `us-east-1` need `region` to be specified. The way to do this (just add `region` to your store config) wasn't obvious to a casual user of the S3 API, so I've added it to the docs.

These docs will solve the issues some folks, including myself, have had with bucket regions:
- https://github.com/Kerry350/ember-deploy-s3-index/issues/20
- https://github.com/Kerry350/ember-deploy-s3-index/issues/25
